### PR TITLE
Don't create sourcemaps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "commonjs",
     "lib": ["es2015", "es2016", "es2017"],
     "strict": true,
-    "sourceMap": true,
     "declaration": true,
     "outDir": "lib/"
   },


### PR DESCRIPTION
Background: The source map referenced the TS file that is not published.