### PR TITLE
Save multiple keys in one call (with single final call to user save f…

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,6 +3,11 @@ export interface KeyStore<PrivateKeyData, PublicKeyData> {
     getPublicKeyData(keyID: string): PublicKeyData;
     getPrivateKeyData(keyID: string, password: string): PrivateKeyData;
     saveKey(keyID: string, password: string, privateData: PrivateKeyData, publicData?: PublicKeyData): Promise<void>;
+    saveKeys(password: string, data: {
+        keyID: string;
+        privateData: PrivateKeyData;
+        publicData?: PublicKeyData;
+    }[]): Promise<void>;
     savePublicKeyData(keyID: string, publicData: PublicKeyData): Promise<void>;
     removeKey(keyID: string): Promise<void>;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,8 +3,9 @@ export interface KeyStore<PrivateKeyData, PublicKeyData> {
     getPublicKeyData(keyID: string): PublicKeyData;
     getPrivateKeyData(keyID: string, password: string): PrivateKeyData;
     saveKey(keyID: string, password: string, privateData: PrivateKeyData, publicData?: PublicKeyData): Promise<void>;
-    saveKeys(password: string, data: {
+    saveKeys(data: {
         keyID: string;
+        password: string;
         privateData: PrivateKeyData;
         publicData?: PublicKeyData;
     }[]): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export interface KeyStore<PrivateKeyData, PublicKeyData> {
   getPublicKeyData (keyID: string): PublicKeyData
   getPrivateKeyData (keyID: string, password: string): PrivateKeyData
   saveKey (keyID: string, password: string, privateData: PrivateKeyData, publicData?: PublicKeyData): Promise<void>
-  saveKeys (password: string, data: {keyID: string, privateData: PrivateKeyData, publicData?: PublicKeyData}[]): Promise<void>
+  saveKeys (data: {keyID: string, password: string, privateData: PrivateKeyData, publicData?: PublicKeyData}[]): Promise<void>
   savePublicKeyData (keyID: string, publicData: PublicKeyData): Promise<void>
   removeKey (keyID: string): Promise<void>
 }
@@ -93,8 +93,8 @@ export function createStore<PrivateKeyData, PublicKeyData = {}> (
       saveKey(keyID, password, privateData, publicData)
       await save(keysData)
     },
-    async saveKeys (password: string, data: {keyID: string, privateData: PrivateKeyData, publicData: PublicKeyData}[]) {
-      data.forEach(d => saveKey(d.keyID, password, d.privateData, d.publicData))
+    async saveKeys (data: {keyID: string, password: string, privateData: PrivateKeyData, publicData: PublicKeyData}[]) {
+      data.forEach(d => saveKey(d.keyID, d.password, d.privateData, d.publicData))
       await save(keysData)
     },
     async savePublicKeyData (keyID: string, publicData: PublicKeyData) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export interface KeyStore<PrivateKeyData, PublicKeyData> {
   getPublicKeyData (keyID: string): PublicKeyData
   getPrivateKeyData (keyID: string, password: string): PrivateKeyData
   saveKey (keyID: string, password: string, privateData: PrivateKeyData, publicData?: PublicKeyData): Promise<void>
+  saveKeys (password: string, data: {keyID: string, privateData: PrivateKeyData, publicData?: PublicKeyData}[]): Promise<void>
   savePublicKeyData (keyID: string, publicData: PublicKeyData): Promise<void>
   removeKey (keyID: string): Promise<void>
 }
@@ -64,6 +65,20 @@ export function createStore<PrivateKeyData, PublicKeyData = {}> (
   const { iterations = 10000 } = options
   let keysData = initialKeys
 
+  function _saveKey (keyID: string, password: string, privateData: PrivateKeyData, publicData: PublicKeyData | {} = {}): void {
+    // Important: Do not re-use previous metadata!
+    // Use a fresh nonce. Also the previous metadata might have been forged.
+    const metadata = {
+      nonce: randomNonce(),
+      iterations
+    }
+    keysData[keyID] = {
+      metadata,
+      public: publicData as any,
+      private: encrypt(privateData, metadata, password)
+    }
+  }
+
   return {
     getKeyIDs () {
       return Object.keys(keysData)
@@ -75,17 +90,11 @@ export function createStore<PrivateKeyData, PublicKeyData = {}> (
       return decrypt(keysData[keyID].private, keysData[keyID].metadata, password) as PrivateKeyData
     },
     async saveKey (keyID: string, password: string, privateData: PrivateKeyData, publicData: PublicKeyData | {} = {}) {
-      // Important: Do not re-use previous metadata!
-      // Use a fresh nonce. Also the previous metadata might have been forged.
-      const metadata = {
-        nonce: randomNonce(),
-        iterations
-      }
-      keysData[keyID] = {
-        metadata,
-        public: publicData as any,
-        private: encrypt(privateData, metadata, password)
-      }
+      _saveKey(keyID, password, privateData, publicData)
+      await save(keysData)
+    },
+    async saveKeys (password: string, data: {keyID: string, privateData: PrivateKeyData, publicData: PublicKeyData}[]) {
+      data.forEach(d => _saveKey(d.keyID, password, d.privateData, d.publicData))
       await save(keysData)
     },
     async savePublicKeyData (keyID: string, publicData: PublicKeyData) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export function createStore<PrivateKeyData, PublicKeyData = {}> (
   const { iterations = 10000 } = options
   let keysData = initialKeys
 
-  function _saveKey (keyID: string, password: string, privateData: PrivateKeyData, publicData: PublicKeyData | {} = {}): void {
+  function saveKey (keyID: string, password: string, privateData: PrivateKeyData, publicData: PublicKeyData | {} = {}): void {
     // Important: Do not re-use previous metadata!
     // Use a fresh nonce. Also the previous metadata might have been forged.
     const metadata = {
@@ -90,11 +90,11 @@ export function createStore<PrivateKeyData, PublicKeyData = {}> (
       return decrypt(keysData[keyID].private, keysData[keyID].metadata, password) as PrivateKeyData
     },
     async saveKey (keyID: string, password: string, privateData: PrivateKeyData, publicData: PublicKeyData | {} = {}) {
-      _saveKey(keyID, password, privateData, publicData)
+      saveKey(keyID, password, privateData, publicData)
       await save(keysData)
     },
     async saveKeys (password: string, data: {keyID: string, privateData: PrivateKeyData, publicData: PublicKeyData}[]) {
-      data.forEach(d => _saveKey(d.keyID, password, d.privateData, d.publicData))
+      data.forEach(d => saveKey(d.keyID, password, d.privateData, d.publicData))
       await save(keysData)
     },
     async savePublicKeyData (keyID: string, publicData: PublicKeyData) {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -44,15 +44,17 @@ test('can save multiple keys', async t => {
   const storage = createMockStorage<PublicData>()
   const store = createStore<PrivateData, PublicData>(storage.save)
 
-  await store.saveKeys('testpassword', [
-    {keyID: 'sample-key', privateData: { key: 'SECRET' }, publicData: { publicData: 'foo' }},
-    {keyID: 'sample-key2', privateData: { key: 'SECRET2' }}
+  await store.saveKeys([
+    {keyID: 'sample-key', password: 'testpassword', privateData: { key: 'SECRET' }, publicData: { publicData: 'foo' }},
+    {keyID: 'sample-key2', password: 'testpassword2', privateData: { key: 'SECRET2' }}
   ])
 
   t.deepEqual(store.getKeyIDs(), ['sample-key', 'sample-key2'])
   t.deepEqual(storage.read()['sample-key'].metadata.iterations, 10000)
   t.deepEqual(storage.read()['sample-key'].public, { publicData: 'foo' })
   t.deepEqual(storage.read()['sample-key2'].public, { })
+  t.deepEqual(store.getPrivateKeyData('sample-key', 'testpassword'), { key: 'SECRET' })
+  t.deepEqual(store.getPrivateKeyData('sample-key2', 'testpassword2'), { key: 'SECRET2' })
 })
 
 test('can read a key', async t => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -38,6 +38,23 @@ test('can save a key', async t => {
   t.deepEqual(storage.read()['sample-key'].public, { publicData: 'foo' })
 })
 
+test('can save multiple keys', async t => {
+  type PublicData = { publicData: string }
+
+  const storage = createMockStorage<PublicData>()
+  const store = createStore<PrivateData, PublicData>(storage.save)
+
+  await store.saveKeys('testpassword', [
+    {keyID: 'sample-key', privateData: { key: 'SECRET' }, publicData: { publicData: 'foo' }},
+    {keyID: 'sample-key2', privateData: { key: 'SECRET2' }}
+  ])
+
+  t.deepEqual(store.getKeyIDs(), ['sample-key', 'sample-key2'])
+  t.deepEqual(storage.read()['sample-key'].metadata.iterations, 10000)
+  t.deepEqual(storage.read()['sample-key'].public, { publicData: 'foo' })
+  t.deepEqual(storage.read()['sample-key2'].public, { })
+})
+
 test('can read a key', async t => {
   type PublicData = { publicData: string }
 


### PR DESCRIPTION
…unction)

Hello, I propose the introduction of a `saveKeys` function that allow to save multiple keys while triggering a single final call to the user defined `save` function. I was needing that new function because I have many cases when I want to update multiple keys at once, and my save function is writing to a file, which can occasionally cause problems:

1. Performance: writing on disk can be expensive, and I only really need eventual consistency so it is fine to bulk save all those changes
2. Inconsistency due to concurrent writing on file

Let me know what you think!