### PR TITLE
Add function to retrieve raw key data

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,6 +2,7 @@ export interface KeyStore<PrivateKeyData, PublicKeyData> {
     getKeyIDs(): string[];
     getPublicKeyData(keyID: string): PublicKeyData;
     getPrivateKeyData(keyID: string, password: string): PrivateKeyData;
+    getRawKeyData(keyID:string): RawKeyData<PublicKeyData>
     saveKey(keyID: string, password: string, privateData: PrivateKeyData, publicData?: PublicKeyData): Promise<void>;
     saveKeys(data: {
         keyID: string;
@@ -16,12 +17,13 @@ interface KeyMetadata {
     nonce: string;
     iterations: number;
 }
+export interface RawKeyData<PublicKeyData> {
+    metadata: KeyMetadata;
+    public: PublicKeyData;
+    private: string;
+}
 export interface KeysData<PublicKeyData> {
-    [keyID: string]: {
-        metadata: KeyMetadata;
-        public: PublicKeyData;
-        private: string;
-    };
+    [keyID: string]: RawKeyData<PublicKeyData>;
 }
 export declare type SaveKeys<PublicKeyData> = (data: KeysData<PublicKeyData>) => Promise<void> | void;
 export declare function createStore<PrivateKeyData, PublicKeyData = {}>(save: SaveKeys<PublicKeyData>, initialKeys?: KeysData<PublicKeyData>, options?: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export interface KeyStore<PrivateKeyData, PublicKeyData> {
   getKeyIDs (): string[]
   getPublicKeyData (keyID: string): PublicKeyData
   getPrivateKeyData (keyID: string, password: string): PrivateKeyData
+  getRawKeyData (keyID: string): RawKeyData<PublicKeyData>
   saveKey (keyID: string, password: string, privateData: PrivateKeyData, publicData?: PublicKeyData): Promise<void>
   saveKeys (data: {keyID: string, password: string, privateData: PrivateKeyData, publicData?: PublicKeyData}[]): Promise<void>
   savePublicKeyData (keyID: string, publicData: PublicKeyData): Promise<void>
@@ -17,12 +18,14 @@ interface KeyMetadata {
   iterations: number
 }
 
+export interface RawKeyData<PublicKeyData> {
+  metadata: KeyMetadata,
+  public: PublicKeyData,
+  private: string
+}
+
 export interface KeysData<PublicKeyData> {
-  [keyID: string]: {
-    metadata: KeyMetadata,
-    public: PublicKeyData,
-    private: string
-  }
+  [keyID: string]: RawKeyData<PublicKeyData>
 }
 
 export type SaveKeys<PublicKeyData> = (data: KeysData<PublicKeyData>) => Promise<void> | void
@@ -85,6 +88,9 @@ export function createStore<PrivateKeyData, PublicKeyData = {}> (
     },
     getPublicKeyData (keyID: string) {
       return keysData[keyID].public
+    },
+    getRawKeyData (keyID: string) {
+      return keysData[keyID]
     },
     getPrivateKeyData (keyID: string, password: string) {
       return decrypt(keysData[keyID].private, keysData[keyID].metadata, password) as PrivateKeyData

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -76,6 +76,7 @@ test('can read a key', async t => {
 
   t.deepEqual(store.getPublicKeyData('test'), { publicData: 'bar' })
   t.deepEqual(store.getPrivateKeyData('test', 'testpassword'), { key: 'SECRET' })
+  t.deepEqual(store.getRawKeyData('test'), initialData['test'])
 })
 
 test('can edit key public data without a password', async t => {


### PR DESCRIPTION
Adds `getRawKeyData(keyID)` to the Keystore to make the key data accessible without having to use the password to decrypt it.